### PR TITLE
Work towards JRuby compatibility

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,4 @@
 --title 'AWS X-Ray SDK for Ruby'
 --markup markdown
---markup-provider rdiscount
 --no-progress
 - LICENSE

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
+
+# These are here instead of the gemspec so that they can be properly conditionalized by platform.
+gem 'oj', platform: :mri
+gem 'jrjackson', platform: :jruby

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 ## Installing
 
-The AWS X-Ray SDK for Ruby is compatible with Ruby 2.3.6 and newer Ruby versions.
+The AWS X-Ray SDK for Ruby is compatible with Ruby 2.3.6 and newer Ruby versions. It has experimental support for JRuby 9.2.0.0 (still forthcoming).
 
-To install the Ruby gem for your project, add it to your project Gemfile.
+To install the Ruby gem for your project, add it to your project Gemfile. You must also add either the [Oj](https://github.com/ohler55/oj) or [JrJackson](https://github.com/guyboertje/jrjackson) gems, for MRI and JRuby respectively, for JSON parsing. The default JSON parser will not work properly, currently.
 
 ```
 # Gemfile
 gem 'aws-xray-sdk'
+gem 'oj', platform: :mri
+gem 'jrjackson', platform: :jruby
 ```
 Then run `bundle install`.
 
@@ -28,7 +30,7 @@ issues for tracking bugs and feature requests.
 If you encounter a bug with the AWS X-Ray SDK for Ruby, we want to hear about
 it. Before opening a new issue, search the [existing issues](https://github.com/aws/aws-xray-sdk-ruby/issues)
 to see if others are also experiencing the issue. Include the version of the AWS X-Ray
-SDK for Ruby, Ruby language, and other gems if applicable. In addition, 
+SDK for Ruby, Ruby language, and other gems if applicable. In addition,
 include the repro case when appropriate.
 
 The GitHub issues are intended for bug reports and feature requests. For help and

--- a/aws-xray-sdk.gemspec
+++ b/aws-xray-sdk.gemspec
@@ -21,14 +21,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'oj', '~> 3.0'
+  spec.add_dependency 'multi_json', '~> 1'
 
   spec.add_development_dependency 'aws-sdk-dynamodb', '~> 1'
   spec.add_development_dependency 'aws-sdk-s3', '~> 1'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rdiscount', '~> 2.2'
   spec.add_development_dependency 'simplecov', '~> 0.15'
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/lib/aws-xray-sdk/facets/aws_sdk.rb
+++ b/lib/aws-xray-sdk/facets/aws_sdk.rb
@@ -25,7 +25,7 @@ module XRay
         operation = context.operation_name
         service_name = context.client.class.api.metadata['serviceAbbreviation'] ||
                        context.client.class.to_s.split('::')[1]
-        recorder.capture service_name, namespace: 'aws' do |subsegment|
+        recorder.capture(service_name, namespace: 'aws') do |subsegment|
           # inject header string before calling downstream AWS services
           context.http_request.headers[TRACE_HEADER] = prep_header_str entity: subsegment
           response = @handler.call(context)

--- a/lib/aws-xray-sdk/facets/rails/railtie.rb
+++ b/lib/aws-xray-sdk/facets/rails/railtie.rb
@@ -6,7 +6,7 @@ module XRay
   class Railtie < ::Rails::Railtie
     RAILS_OPTIONS = %I[active_record].freeze
 
-    initializer "aws-xray-sdk.rack_middleware" do |app|
+    initializer("aws-xray-sdk.rack_middleware") do |app|
       app.middleware.insert 0, Rack::Middleware
       app.middleware.use XRay::Rails::ExceptionMiddleware
     end

--- a/lib/aws-xray-sdk/model/cause.rb
+++ b/lib/aws-xray-sdk/model/cause.rb
@@ -1,4 +1,4 @@
-require 'oj'
+require 'multi_json'
 
 module XRay
   # Represents cause section in segment and subsegment document.
@@ -26,7 +26,7 @@ module XRay
 
     def to_json
       @to_json ||= begin
-        Oj.dump to_h, mode: :compat, use_as_json: true
+        MultiJson.dump to_h
       end
     end
 

--- a/lib/aws-xray-sdk/model/entity.rb
+++ b/lib/aws-xray-sdk/model/entity.rb
@@ -1,6 +1,6 @@
 require 'securerandom'
 require 'bigdecimal'
-require 'oj'
+require 'multi_json'
 require 'aws-xray-sdk/exceptions'
 require 'aws-xray-sdk/model/cause'
 require 'aws-xray-sdk/model/annotations'
@@ -168,7 +168,7 @@ module XRay
 
     def to_json
       @to_json ||= begin
-        Oj.dump to_h, mode: :compat, use_as_json: true
+        MultiJson.dump(to_h)
       end
     end
 

--- a/lib/aws-xray-sdk/model/metadata.rb
+++ b/lib/aws-xray-sdk/model/metadata.rb
@@ -1,4 +1,4 @@
-require 'oj'
+require 'multi_json'
 require 'aws-xray-sdk/exceptions'
 
 module XRay
@@ -48,7 +48,7 @@ module XRay
 
     def to_json
       @to_json ||= begin
-        Oj.dump to_h, mode: :compat, use_as_json: true
+        MultiJson.dump to_h
       end
     end
   end

--- a/lib/aws-xray-sdk/plugins/elastic_beanstalk.rb
+++ b/lib/aws-xray-sdk/plugins/elastic_beanstalk.rb
@@ -1,4 +1,4 @@
-require 'oj'
+require 'multi_json'
 require 'aws-xray-sdk/logger'
 
 module XRay
@@ -14,7 +14,7 @@ module XRay
       def self.aws
         @@aws ||= begin
           file = File.open(CONF_PATH)
-          { elastic_beanstalk: Oj.load(file) }
+          { elastic_beanstalk: MultiJson.load(file) }
         rescue StandardError => e
           @@aws = {}
           Logging.logger.warn %(can not get the environment config due to: #{e.message}.)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,12 @@ SimpleCov.start
 require 'minitest/autorun'
 require 'aws-xray-sdk/emitter/emitter'
 
+if RUBY_PLATFORM == 'java'
+  require 'jrjackson'
+else
+  require 'oj'
+end
+
 module XRay
   # holds all testing needed classes and methods
   module TestHelper


### PR DESCRIPTION
This is part of #4. Until JRuby 9.2.0.0 is released, the
required_ruby_version in the gemspec will keep this from working there,
as well as jruby/jruby#5099.

* Replaced Oj with MultiJson + Oj OR JrJackson
* Removed Oj.dump parameters, since those are defaults when using MultiJson
* Remove rdiscount for Markdown generation, use default Yard generator.
* Made two minor code syntax changes to make the Yard generator happy

I've roughly compared the generated RDoc and they look very similar.