### PR TITLE
Fix bug. Call once if current_entity is nil

### DIFF
--- a/lib/aws-xray-sdk/facets/aws_sdk.rb
+++ b/lib/aws-xray-sdk/facets/aws_sdk.rb
@@ -19,7 +19,7 @@ module XRay
       def call(context)
         recorder = Aws.config[:xray_recorder]
         if recorder.current_entity.nil?
-          super
+          return super
         end
 
         operation = context.operation_name


### PR DESCRIPTION
Fix bug. `hander.call` is invoked twice if current_entity is nil.
