### PR TITLE
Return tracing header in Rack/Rails HTTP response to support passing trace information via JS apps

### DIFF
--- a/lib/aws-xray-sdk/facets/helper.rb
+++ b/lib/aws-xray-sdk/facets/helper.rb
@@ -42,12 +42,7 @@ module XRay
 
       # Prepares a X-Ray header string based on the provided Segment/Subsegment.
       def prep_header_str(entity:)
-        return '' if entity.nil?
-        root = entity.segment.trace_id
-        parent_id = entity.id
-        sampled = entity.sampled ? 1 : 0
-        header = TraceHeader.new root: root, parent_id: parent_id, sampled: sampled
-        header.header_string
+        TraceHeader.from_entity(entity: entity).header_string
       end
     end
   end

--- a/lib/aws-xray-sdk/facets/rack.rb
+++ b/lib/aws-xray-sdk/facets/rack.rb
@@ -49,7 +49,7 @@ module XRay
             resp_meta[:content_length] = len
           end
           segment.merge_http_response response: resp_meta
-          trace_header = {TRACE_HEADER => TraceHeader.from_entity(entity: XRay.recorder.current_segment).root_string}
+          trace_header = {TRACE_HEADER => TraceHeader.from_entity(entity: segment).root_string}
           headers.merge!(trace_header)
           [status, headers, body]
         rescue Exception => e

--- a/lib/aws-xray-sdk/facets/rack.rb
+++ b/lib/aws-xray-sdk/facets/rack.rb
@@ -49,7 +49,7 @@ module XRay
             resp_meta[:content_length] = len
           end
           segment.merge_http_response response: resp_meta
-          trace_header = {TRACE_HEADER => prep_header_str(entity: XRay.recorder.current_segment)}
+          trace_header = {TRACE_HEADER => TraceHeader.from_entity(entity: XRay.recorder.current_segment).root_string}
           headers.merge!(trace_header)
           [status, headers, body]
         rescue Exception => e

--- a/lib/aws-xray-sdk/facets/rack.rb
+++ b/lib/aws-xray-sdk/facets/rack.rb
@@ -49,6 +49,8 @@ module XRay
             resp_meta[:content_length] = len
           end
           segment.merge_http_response response: resp_meta
+          trace_header = {TRACE_HEADER => prep_header_str(entity: XRay.recorder.current_segment)}
+          headers.merge!(trace_header)
           [status, headers, body]
         rescue Exception => e
           segment.apply_status_code status: 500

--- a/lib/aws-xray-sdk/model/trace_header.rb
+++ b/lib/aws-xray-sdk/model/trace_header.rb
@@ -18,6 +18,14 @@ module XRay
       @sampled = sampled.to_i if sampled
     end
 
+    def self.from_entity(entity:)
+      return empty_header if entity.nil?
+      root = entity.segment.trace_id
+      parent_id = entity.id
+      sampled = entity.sampled ? 1 : 0
+      new root: root, parent_id: parent_id, sampled: sampled
+    end
+
     def self.from_header_string(header_str:)
       empty_header if header_str.to_s.empty?
       header = header_str.delete(' ').downcase
@@ -35,15 +43,20 @@ module XRay
       end
     end
 
+    # @return [String] The header string of the root object
+    def root_string
+	%(Root=#{root})
+    end
+
     # @return [String] The heading string constructed based on this header object.
     def header_string
       return '' unless root
       if !parent_id
-        %(Root=#{root};Sampled=#{sampled})
+        %(#{root_string};Sampled=#{sampled})
       elsif !sampled
-        %(Root=#{root};Parent=#{parent_id})
+        %(#{root_string};Parent=#{parent_id})
       else
-        %(Root=#{root};Parent=#{parent_id};Sampled=#{sampled})
+        %(#{root_string};Parent=#{parent_id};Sampled=#{sampled})
       end
     end
 

--- a/test/aws-xray-sdk/tc_facet_rack.rb
+++ b/test/aws-xray-sdk/tc_facet_rack.rb
@@ -63,4 +63,11 @@ class TestFacetRack < Minitest::Test
     segment = @@recorder.emitter.entities[0]
     assert_equal "http://localhost:3000/index.html", segment.http_request[:url]
   end
+
+  def test_rack_returns_xray_header
+    middleware = XRay::Rack::Middleware.new(@@app, :recorder => @@recorder)
+    _, headers, _ = middleware.call ENV_WITH_QUERY_STRING
+    assert_equal true, headers.has_key?(XRay::Facets::Helper::TRACE_HEADER)
+  end
+
 end

--- a/test/aws-xray-sdk/tc_facet_rack.rb
+++ b/test/aws-xray-sdk/tc_facet_rack.rb
@@ -68,6 +68,9 @@ class TestFacetRack < Minitest::Test
     middleware = XRay::Rack::Middleware.new(@@app, :recorder => @@recorder)
     _, headers, _ = middleware.call ENV_WITH_QUERY_STRING
     assert_equal true, headers.has_key?(XRay::Facets::Helper::TRACE_HEADER)
+    assert_match /^Root=/, headers[XRay::Facets::Helper::TRACE_HEADER]
+    refute_match /ParentId=/, headers[XRay::Facets::Helper::TRACE_HEADER]
+    refute_match /Sampled=/, headers[XRay::Facets::Helper::TRACE_HEADER]
   end
 
 end


### PR DESCRIPTION
In our case, we have a Rails application, that the user has the first interaction with. This is where the trace is started. From here a Javascript app in the browser takes over any further interaction and calls different API subsystems. In order to pass the tracing information to these API subsystems and continue the original trace, this PR introduces responding with the `X-Amzn-Trace-Id` header in the Rack/Rails response.

I had noticed that e.g. https://github.com/aws/aws-xray-sdk-go is responding with the `X-Amzn-Trace-Id` header by default once the http middleware is configured, which makes my think it's wanted default behaviour.

Looking forward to hearing your feedback about whether this being the right approach. I am also wondering if it's worth making this configurable in any way or can be default behaviour as observed in the Go SDK.

Best, Lars

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
