### PR TITLE
fix: custom daemon addres raise error

### DIFF
--- a/lib/aws-xray-sdk/configuration.rb
+++ b/lib/aws-xray-sdk/configuration.rb
@@ -42,7 +42,7 @@ module XRay
     # setting daemon address for components communicate with X-Ray daemon.
     def daemon_address=(v)
       v = ENV[DaemonConfig::DAEMON_ADDRESS_KEY] || v
-      config = DaemonConfig.new(v)
+      config = DaemonConfig.new(addr: v)
       emitter.daemon_config = config
       sampler.daemon_config = config if sampler.respond_to?(:daemon_config=)
     end

--- a/lib/aws-xray-sdk/context/default_context.rb
+++ b/lib/aws-xray-sdk/context/default_context.rb
@@ -12,7 +12,7 @@ module XRay
 
     LOCAL_KEY = '_aws_xray_entity'.freeze
     CONTEXT_MISSING_KEY = 'AWS_XRAY_CONTEXT_MISSING'.freeze
-    SUPPORTED_STRATEGY = %w[RUNTIME_ERROR LOG_ERROR].freeze
+    SUPPORTED_STRATEGY = %w[RUNTIME_ERROR LOG_ERROR IGNORE_ERROR].freeze
     DEFAULT_STRATEGY = SUPPORTED_STRATEGY[0]
 
     attr_reader :context_missing

--- a/lib/aws-xray-sdk/model/entity.rb
+++ b/lib/aws-xray-sdk/model/entity.rb
@@ -143,7 +143,9 @@ module XRay
       else
         h[:in_progress] = true
       end
-      h[:subsegments] = subsegments unless subsegments.empty?
+
+      h[:subsegments] = subsegments.map(&:to_h) unless subsegments.empty?
+
       h[:aws] = aws if aws
       if http_request || http_response
         h[:http] = {}

--- a/lib/aws-xray-sdk/model/metadata.rb
+++ b/lib/aws-xray-sdk/model/metadata.rb
@@ -17,7 +17,11 @@ module XRay
     end
 
     def to_h
-      @data
+      @data.keys.each_with_object({}) do |key, h|
+        h[key] = @data[key].to_h
+        h
+      end
+
     end
   end
 

--- a/lib/aws-xray-sdk/sampling/local/sampler.rb
+++ b/lib/aws-xray-sdk/sampling/local/sampler.rb
@@ -58,7 +58,7 @@ module XRay
       return sample if sampling_req.nil? || sampling_req.empty?
       @custom_rules ||= []
       @custom_rules.each do |c|
-        return should_sample?(c) if c.applies?(sampling_req: sampling_req)
+        return should_sample?(c) if c.applies?(sampling_req)
       end
       # use previously made decision based on default rule
       # if no path-based rule has been matched


### PR DESCRIPTION
1. DaemonConfig initialize hash as parameter, but in `configuration.rb` , it pass the string value of `deamon_address`

2. Local sampling rule accept req object as `applies?` parameter, but local sampler using nested obj as `{ sampling_req: sampling_req }`

3. entity.to_h method should convert `subsegments` to hash

4. Metadata.to_h should convert all sub meta to hash

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
