### PR TITLE
fix wrong number of arguments when calling to_json

### DIFF
--- a/lib/aws-xray-sdk/model/cause.rb
+++ b/lib/aws-xray-sdk/model/cause.rb
@@ -24,7 +24,7 @@ module XRay
       h
     end
 
-    def to_json
+    def to_json(*)
       @to_json ||= begin
         MultiJson.dump to_h
       end

--- a/lib/aws-xray-sdk/model/dummy_entities.rb
+++ b/lib/aws-xray-sdk/model/dummy_entities.rb
@@ -46,7 +46,7 @@ module XRay
       # no-op
     end
 
-    def to_json
+    def to_json(*)
       # no-op
     end
   end

--- a/lib/aws-xray-sdk/model/entity.rb
+++ b/lib/aws-xray-sdk/model/entity.rb
@@ -168,7 +168,7 @@ module XRay
       h
     end
 
-    def to_json
+    def to_json(*)
       @to_json ||= begin
         MultiJson.dump(to_h)
       end

--- a/lib/aws-xray-sdk/model/metadata.rb
+++ b/lib/aws-xray-sdk/model/metadata.rb
@@ -50,7 +50,7 @@ module XRay
       @data
     end
 
-    def to_json
+    def to_json(*)
       @to_json ||= begin
         MultiJson.dump to_h
       end


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Fix `wrong number of arguments (given 1, expected 0)` from inside MultiJson when calling `end_segment`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
