### PR TITLE
Fixed issue where wrong DB-connection was returned

### DIFF
--- a/lib/aws-xray-sdk/facets/rails/active_record.rb
+++ b/lib/aws-xray-sdk/facets/rails/active_record.rb
@@ -52,6 +52,7 @@ module XRay
           ::ActiveRecord::Base.connection_handler.connection_pool_list.each do |p|
             conn = p.connections.select { |c| c.object_id == conn_id }
             pool = p unless conn.nil?
+            return [pool, conn] if !conn.nil? && !conn.empty? && !pool.nil?
           end
           [pool, conn]
         end


### PR DESCRIPTION

When using multiple databases, the method get_pool_n_conn will
give the wrong database connection at times due to the method don't return early,
and any found connections can be overridden in the next iteration of the loop over the
connection pool list.


*Description of changes:*
This fix makes the method get_pool_n_conn return early when a matching
connection has been found.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
