### PR TITLE
Whitelist SageMakerRuntime InvokeEndpoint operation

### DIFF
--- a/lib/aws-xray-sdk/facets/resources/aws_params_whitelist.rb
+++ b/lib/aws-xray-sdk/facets/resources/aws_params_whitelist.rb
@@ -330,6 +330,15 @@ module XRay
             }
           }
         },
+        SageMakerRuntime: {
+          operations: {
+            invoke_endpoint: {
+              request_parameters: %I[
+                endpoint_name
+              ]
+            }
+          }
+        },
         SNS: {
           operations: {
             publish: {


### PR DESCRIPTION
Operation name and request param acquired from this documentation:
https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SageMakerRuntime/Client.html#invoke_endpoint-instance_method

Sample subsegment from end-to-end test, works as expected
```
{
    "id": "3ccad1cc5582980a",
    "name": "SageMakerRuntime",
    "start_time": 1573586225.372278,
    "end_time": 1573586225.754407,
    "http": {
        "response": {
            "status": 200,
            "content_length": 3
        }
    },
    "aws": {
        "operation": "InvokeEndpoint",
        "region": "us-east-1",
        "retries": 0,
        "request_id": "658bb318-1366-4804-bb52-bfffb18fd38a",
        "endpoint_name": "test-endpoint-1",
        "resource_names": [
            "test-endpoint-1"
        ]
    },
    "namespace": "aws"
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
