### PR TITLE
Do not log Lambda runtime segments

### DIFF
--- a/lib/aws-xray-sdk/facets/net_http.rb
+++ b/lib/aws-xray-sdk/facets/net_http.rb
@@ -20,12 +20,10 @@ module XRay
         super(*options)
       end
 
-      # HTTP requests to AWS Lambda Ruby Runtime will begin with the
-      # value set in ENV['AWS_LAMBDA_RUNTIME_API']
-      def lambda_runtime_request?(req)
-        ENV['AWS_LAMBDA_RUNTIME_API']  &&
-          req.uri &&
-          req.uri.to_s.start_with?('http://'+ENV['AWS_LAMBDA_RUNTIME_API']+'/')
+      # HTTP requests to AWS Lambda Ruby Runtime will have the address and port
+      # matching the value set in ENV['AWS_LAMBDA_RUNTIME_API']
+      def lambda_runtime_request?
+        ENV['AWS_LAMBDA_RUNTIME_API'] == "#{address}:#{port}"
       end
 
       def xray_sampling_request?(req)
@@ -34,7 +32,7 @@ module XRay
 
       def request(req, body = nil, &block)
         # Do not trace requests to xray or aws lambda runtime
-        if xray_sampling_request?(req) || lambda_runtime_request?(req)
+        if xray_sampling_request?(req) || lambda_runtime_request?
           return super
         end
 

--- a/test/aws-xray-sdk/tc_facet_net_http.rb
+++ b/test/aws-xray-sdk/tc_facet_net_http.rb
@@ -1,0 +1,30 @@
+require_relative '../test_helper'
+require 'aws-xray-sdk/facets/net_http'
+
+class TestFacetNetHttp < Minitest::Test
+
+  def setup
+    ENV['AWS_LAMBDA_RUNTIME_API'] = 'localhost:3000'
+  end
+
+  def teardown
+    ENV.delete('AWS_LAMBDA_RUNTIME_API')
+  end
+
+  def test_lambda_runtime_request_true
+    http = Net::HTTP.new('localhost',3000)
+    assert http.lambda_runtime_request?
+  end
+
+  def test_lambda_runtime_request_false
+    http = Net::HTTP.new('www.example.com',3000)
+    refute http.lambda_runtime_request?
+  end
+
+  def test_lambda_runtime_request_nil_env
+    ENV.delete('AWS_LAMBDA_RUNTIME_API')
+    refute ENV['AWS_LAMBDA_RUNTIME_API']
+    http = Net::HTTP.new('www.example.com',3000)
+    refute http.lambda_runtime_request?
+  end
+end


### PR DESCRIPTION
*Issue #38*

Refactored the `lambda_runtime_request?` method and added tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
