### PR TITLE
add missing rds data service sdk

### DIFF
--- a/lib/aws-xray-sdk/facets/resources/aws_services_whitelist.rb
+++ b/lib/aws-xray-sdk/facets/resources/aws_services_whitelist.rb
@@ -102,6 +102,7 @@ module XRay
       Polly
       Pricing
       RDS
+      RDSDataService
       Redshift
       Rekognition
       ResourceGroups


### PR DESCRIPTION
*Description of changes:*

When I was trying to use the RDS Data API client it threw errors because it wasn't patching it as it's missing from the services list.

For anyone that needs a workaround in the meantime it's...

```ruby
require "aws-xray-sdk/facets/resources/aws_services_whitelist"
XRay::AwsServices.whitelist << :RDSDataService
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
