### PR TITLE
fix: avoid deprecation warning on Rails 6.1

### DIFF
--- a/lib/aws-xray-sdk/facets/rails/active_record.rb
+++ b/lib/aws-xray-sdk/facets/rails/active_record.rb
@@ -21,7 +21,7 @@ module XRay
           db_config = if pool.respond_to?(:spec)
                         pool.spec.config
                       else
-                        pool.db_config.config.symbolize_keys
+                        pool.db_config.configuration_hash
                       end
           name, sql = build_name_sql_meta config: db_config, conn: conn
           subsegment = XRay.recorder.begin_subsegment name, namespace: 'remote'


### PR DESCRIPTION
*Issue #, if available:* #56

And related to #56 's comment: https://github.com/aws/aws-xray-sdk-ruby/issues/56#issuecomment-759722830

*Description of changes:* Avoid deprecation warning on Rails 6.1 and enabled ActiveRecord


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
