### PR TITLE
Modifies error logger language

### DIFF
--- a/lib/aws-xray-sdk/context/default_context.rb
+++ b/lib/aws-xray-sdk/context/default_context.rb
@@ -57,7 +57,7 @@ module XRay
       when 'RUNTIME_ERROR'
         raise ContextMissingError
       when 'LOG_ERROR'
-        logger.error %(can not find the current context.)
+        logger.error %(cannot find the current context.)
       end
       nil
     end

--- a/lib/aws-xray-sdk/exceptions.rb
+++ b/lib/aws-xray-sdk/exceptions.rb
@@ -10,7 +10,7 @@ module XRay
 
   class ContextMissingError < AwsXRaySdkError
     def initialize
-      super('Can not find any active segment or subsegment.')
+      super('Cannot find any active segment or subsegment.')
     end
   end
 

--- a/lib/aws-xray-sdk/plugins/ec2.rb
+++ b/lib/aws-xray-sdk/plugins/ec2.rb
@@ -33,7 +33,7 @@ module XRay
         begin
           return do_request(req)
         rescue StandardError => e
-          Logging.logger.warn %(can not get the IMDSv2 token due to: #{e.message}.)
+          Logging.logger.warn %(cannot get the IMDSv2 token due to: #{e.message}.)
           ''
         end
       end
@@ -50,7 +50,7 @@ module XRay
           metadata_json = do_request(req)
           return parse_metadata(metadata_json)
         rescue StandardError => e
-          Logging.logger.warn %(can not get the ec2 instance metadata due to: #{e.message}.)
+          Logging.logger.warn %(cannot get the ec2 instance metadata due to: #{e.message}.)
           {}
         end
       end

--- a/lib/aws-xray-sdk/plugins/ecs.rb
+++ b/lib/aws-xray-sdk/plugins/ecs.rb
@@ -15,7 +15,7 @@ module XRay
           { ecs: { container: Socket.gethostname } }
         rescue StandardError => e
           @@aws = {}
-          Logging.logger.warn %(can not get the ecs container hostname due to: #{e.message}.)
+          Logging.logger.warn %(cannot get the ecs container hostname due to: #{e.message}.)
         end
       end
     end

--- a/lib/aws-xray-sdk/plugins/elastic_beanstalk.rb
+++ b/lib/aws-xray-sdk/plugins/elastic_beanstalk.rb
@@ -17,7 +17,7 @@ module XRay
           { elastic_beanstalk: MultiJson.load(file) }
         rescue StandardError => e
           @@aws = {}
-          Logging.logger.warn %(can not get the environment config due to: #{e.message}.)
+          Logging.logger.warn %(cannot get the environment config due to: #{e.message}.)
         end
       end
     end


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modified error logger language so that `cannot` is now one word and more easily searchable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
