### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -20,6 +20,7 @@ jobs:
           - 2.4
           - 2.5
           - 2.6
+          - 2.7
     steps:
       - uses: actions/checkout@v1
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -33,6 +33,8 @@ jobs:
       # Implicitly verifies that CHANGELOG and version.rb match
       - name: Push gem
         run: gem push aws-xray-sdk-${{ env.VERSION }}.gem
+      - name: Clear credentials
+        run: rm ~/.gem/credentials
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -25,6 +25,11 @@ jobs:
         run: echo "VERSION_NO_DOTS=$(echo $VERSION | sed s/\\.//g)" >> $GITHUB_ENV
       - name: Build gem
         run: gem build aws-xray-sdk.gemspec
+      - name: Set API key credentials
+        run: |
+          echo ":rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
       # Implicitly verifies that CHANGELOG and version.rb match
       - name: Push gem
         run: gem push aws-xray-sdk-${{ env.VERSION }}.gem

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,40 @@
+name: Release Build
+
+on:
+  push:
+    paths:
+      - 'CHANGELOG.md'
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: bundle exec rake test
+      - name: Extract version from CHANGELOG.md
+        run: echo "VERSION=$(echo $(head -n 1 CHANGELOG.md) | awk -F ' ' '{print $1}')" >> $GITHUB_ENV
+      - name: Extract date from CHANGELOG.md
+        run: echo "DATE=$(echo $(head -n 1 CHANGELOG.md) | awk -F '[()]' '{print $2}')" >> $GITHUB_ENV
+      - name: Remove dots for VERSION for use in release notes
+        run: echo "VERSION_NO_DOTS=$(echo $VERSION | sed s/\\.//g)" >> $GITHUB_ENV
+      - name: Build gem
+        run: gem build aws-xray-sdk.gemspec
+      # Implicitly verifies that CHANGELOG and version.rb match
+      - name: Push gem
+        run: gem push aws-xray-sdk-${{ env.VERSION }}.gem
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          release_name: Release ${{ env.VERSION }}
+          body: "Please refer the [Changelog](https://github.com/aws/aws-xray-sdk-ruby/blob/master/CHANGELOG.md#${{ env.VERSION_NO_DOTS }}-${{ env.DATE }}) for more details."
+          prerelease: false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Automatically runs the RELEASE when making a change to the CHANGELOG. If we feel this is too automatic because of post-release CHANGELOG edits (I think it's rare enough for this repo at least), we could make it manual trigger instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
