### PR TITLE
Resolve :xray_recorder issue for Aws::IVS::Client

### DIFF
--- a/lib/aws-xray-sdk/facets/resources/aws_services_whitelist.rb
+++ b/lib/aws-xray-sdk/facets/resources/aws_services_whitelist.rb
@@ -103,6 +103,7 @@ module XRay
       GuardDuty
       Health
       IAM
+      IVS
       Imagebuilder
       ImportExport
       Inspector


### PR DESCRIPTION
When using the `aws-xray-sdk` with the `aws-ivs-sdk`, the following error is produced:

`invalid configuration option :xray_recorder Aws::IVS::Client`

This PR updates the service whitelist to include IVS, resulting in proper patching of `aws-ivs-sdk` for X-Ray.

This fix is similar to issue #26.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
