### PR TITLE
Whitelist Location Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+master
+-------------------
+
+* Added - Whitelist the LocationService client for instrumentation [PR #77](https://github.com/aws/aws-xray-sdk-ruby/pull/77).
+
 0.12.0 (2021-04-01)
 -------------------
 * Added - Added support for Rails 6.1 ActiveRecord [PR #57](https://github.com/aws/aws-xray-sdk-ruby/pull/57)
@@ -39,7 +44,7 @@
 * **Breaking**: The sampling modules related to local sampling rules have been renamed and moved to `sampling/local` namespace.
 * **Breaking**: The default json serializer is switched to `multi_json` for experimental JRuby support. Now you need to specify `oj` or `jrjackson` in Gemfile. [PR#5](https://github.com/aws/aws-xray-sdk-ruby/pull/5)
 * **Breaking**: The SDK now requires `aws-sdk-xray` >= `1.4.0`.
-* Feature: Environment variable `AWS_XRAY_DAEMON_ADDRESS` now takes an additional notation in `tcp:127.0.0.1:2000 udp:127.0.0.2:2001` to set TCP and UDP destination separately. By default it assumes a X-Ray daemon listening to both UDP and TCP traffic on `127.0.0.1:2000`. 
+* Feature: Environment variable `AWS_XRAY_DAEMON_ADDRESS` now takes an additional notation in `tcp:127.0.0.1:2000 udp:127.0.0.2:2001` to set TCP and UDP destination separately. By default it assumes a X-Ray daemon listening to both UDP and TCP traffic on `127.0.0.1:2000`.
 * Bugfix - Call only once if `current_entity` is nil. [PR#9](https://github.com/aws/aws-xray-sdk-ruby/pull/9)
 
 0.10.2 (2018-03-30)

--- a/lib/aws-xray-sdk/facets/resources/aws_services_allowlist.rb
+++ b/lib/aws-xray-sdk/facets/resources/aws_services_allowlist.rb
@@ -136,6 +136,7 @@ module XRay
       LexRuntimeService
       LicenseManager
       Lightsail
+      LocationService
       MachineLearning
       Macie
       ManagedBlockchain


### PR DESCRIPTION
Hi There!

I noticed that the `LocationService` client wasn't in the whitelist so the following error was generated when trying to use the service:

```
invalid configuration option `:xray_recorder'
```

I see that there's a number of PRs to add new services to the whitelist such as [#72](https://github.com/aws/aws-xray-sdk-ruby/pull/72).

Have you considered a blacklist approach instead? That way new services would be instrumented by default when released, with a blacklist to ignore those that cause issues.

*Description of changes:*

* Add the `LocationService` client to the service whitelist so that
  the client can be properly instrumented.

SEE: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/LocationService.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
