### PR TITLE
Change context missing strategy behaviour to Log Error

### DIFF
--- a/lib/aws-xray-sdk/context/default_context.rb
+++ b/lib/aws-xray-sdk/context/default_context.rb
@@ -13,7 +13,7 @@ module XRay
     LOCAL_KEY = '_aws_xray_entity'.freeze
     CONTEXT_MISSING_KEY = 'AWS_XRAY_CONTEXT_MISSING'.freeze
     SUPPORTED_STRATEGY = %w[RUNTIME_ERROR LOG_ERROR IGNORE_ERROR].freeze
-    DEFAULT_STRATEGY = SUPPORTED_STRATEGY[0]
+    DEFAULT_STRATEGY = SUPPORTED_STRATEGY[1]
 
     attr_reader :context_missing
 

--- a/test/aws-xray-sdk/tc_context.rb
+++ b/test/aws-xray-sdk/tc_context.rb
@@ -20,14 +20,15 @@ class TestContext < Minitest::Test
     context = XRay::DefaultContext.new
     context.clear!
     context.context_missing = 'UNKWON'
-    assert_equal 'RUNTIME_ERROR', context.context_missing
-    context.context_missing = 'LOG_ERROR'
     assert_equal 'LOG_ERROR', context.context_missing
+    context.context_missing = 'RUNTIME_ERROR'
+    assert_equal 'RUNTIME_ERROR', context.context_missing
   end
 
   def test_runtime_error
     context = XRay::DefaultContext.new
     context.clear!
+    context.context_missing = 'RUNTIME_ERROR'
     assert_raises XRay::ContextMissingError do
       context.current_entity
     end
@@ -36,7 +37,6 @@ class TestContext < Minitest::Test
   def test_log_error
     context = XRay::DefaultContext.new
     context.clear!
-    context.context_missing = 'LOG_ERROR'
     refute context.current_entity
   end
 end

--- a/test/aws-xray-sdk/tc_context.rb
+++ b/test/aws-xray-sdk/tc_context.rb
@@ -19,7 +19,7 @@ class TestContext < Minitest::Test
   def test_change_context_missing
     context = XRay::DefaultContext.new
     context.clear!
-    context.context_missing = 'UNKWON'
+    context.context_missing = 'INVALID_STRATEGY'
     assert_equal 'LOG_ERROR', context.context_missing
     context.context_missing = 'RUNTIME_ERROR'
     assert_equal 'RUNTIME_ERROR', context.context_missing
@@ -35,6 +35,13 @@ class TestContext < Minitest::Test
   end
 
   def test_log_error
+    context = XRay::DefaultContext.new
+    context.clear!
+    context.context_missing = 'LOG_ERROR'
+    refute context.current_entity
+  end
+
+  def test_default_context_missing
     context = XRay::DefaultContext.new
     context.clear!
     refute context.current_entity

--- a/test/aws-xray-sdk/tc_recorder.rb
+++ b/test/aws-xray-sdk/tc_recorder.rb
@@ -39,8 +39,23 @@ class TestRecorder < Minitest::Test
     segment = @@recorder.begin_segment name: name
     @@recorder.end_segment
     assert_equal segment, @@recorder.emitter.entities[0]
+  end
+
+  def test_send_segment_with_ctx_missing_runtime_error
+    recorder = XRay::Recorder.new
+    config = {
+      context_missing: 'RUNTIME_ERROR',
+      sampling: false,
+      emitter: XRay::TestHelper::StubbedEmitter.new,
+      sampler: XRay::TestHelper::StubbedDefaultSampler.new
+    }
+    recorder.configure(config)
+
+    segment = recorder.begin_segment name: name
+    recorder.end_segment
+    assert_equal segment, recorder.emitter.entities[0]
     assert_raises XRay::ContextMissingError do
-      @@recorder.current_segment
+      recorder.current_segment
     end
   end
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change sets the default context missing strategy to 'LOG_ERROR' instead of 'RUNTIME_ERROR' to mitigate malformed trace headers from breaking services.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
