### PR TITLE
Prevent warnings variable @metadata not initialised

### DIFF
--- a/lib/aws-xray-sdk/model/entity.rb
+++ b/lib/aws-xray-sdk/model/entity.rb
@@ -155,7 +155,9 @@ module XRay
       if (a = annotations.to_h) && !a.empty?
         h[:annotations] = a
       end
-      if (m = metadata) && !m.to_h.empty?
+      # make sure @metadata is initialized before evaluating it, to prevent warning `variable @metadata not initialized`
+      metadata
+      if (m = @metadata) && !m.to_h.empty?
         h[:metadata] = m.to_h
       end
 

--- a/lib/aws-xray-sdk/model/entity.rb
+++ b/lib/aws-xray-sdk/model/entity.rb
@@ -155,7 +155,7 @@ module XRay
       if (a = annotations.to_h) && !a.empty?
         h[:annotations] = a
       end
-      # make sure @metadata is initialized before evaluating it, to prevent warning `variable @metadata not initialized`
+      # make sure @metadata is defined before evaluating it, to prevent warning `variable @metadata not initialized`
       if (defined?(@metadata) && m = @metadata) && !m.to_h.empty?
         h[:metadata] = m.to_h
       end

--- a/lib/aws-xray-sdk/model/entity.rb
+++ b/lib/aws-xray-sdk/model/entity.rb
@@ -155,7 +155,7 @@ module XRay
       if (a = annotations.to_h) && !a.empty?
         h[:annotations] = a
       end
-      if (m = @metadata) && !m.to_h.empty?
+      if (m = metadata) && !m.to_h.empty?
         h[:metadata] = m.to_h
       end
 

--- a/lib/aws-xray-sdk/model/entity.rb
+++ b/lib/aws-xray-sdk/model/entity.rb
@@ -156,8 +156,7 @@ module XRay
         h[:annotations] = a
       end
       # make sure @metadata is initialized before evaluating it, to prevent warning `variable @metadata not initialized`
-      metadata
-      if (m = @metadata) && !m.to_h.empty?
+      if (defined?(@metadata) && m = @metadata) && !m.to_h.empty?
         h[:metadata] = m.to_h
       end
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-ruby/issues/84

*Description of changes:*
Instead of directly using `@metadata`, use the `metadata` method in charge of doing an initialization when necessary

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
