### PR TITLE
Make begin_segment's name argument optional

### DIFF
--- a/lib/aws-xray-sdk/recorder.rb
+++ b/lib/aws-xray-sdk/recorder.rb
@@ -24,7 +24,7 @@ module XRay
     # only keeps one segment at a time. Create a second one without
     # closing existing one will overwrite the existing one.
     # @return [Segment] thew newly created segment.
-    def begin_segment(name, trace_id: nil, parent_id: nil, sampled: nil)
+    def begin_segment(name: nil, trace_id: nil, parent_id: nil, sampled: nil)
       seg_name = name || config.name
       raise SegmentNameMissingError if seg_name.to_s.empty?
 


### PR DESCRIPTION
*Issue, if available:*

#87 

*Description of changes:*

Name already uses a fallback to config.name so can be optional

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
