### PR TITLE
Add cloudwatch logs to aws context in traces

### DIFF
--- a/lib/aws-xray-sdk/recorder.rb
+++ b/lib/aws-xray-sdk/recorder.rb
@@ -222,6 +222,13 @@ module XRay
           }
         }
         aws.merge! xray_meta
+        cloudwatch_meta = {
+          cloudwatch_logs: {
+            log_group: "???"
+            arn: "???"
+          }
+        }
+        aws.merge! cloudwatch_meta
       end
 
       @service ||= {

--- a/lib/aws-xray-sdk/recorder.rb
+++ b/lib/aws-xray-sdk/recorder.rb
@@ -224,6 +224,7 @@ module XRay
         aws.merge! xray_meta
         cloudwatch_meta = {
           cloudwatch_logs: {
+            # Help me: Are the log_group and arn for already available somewhere in the SDK ?
             log_group: "???"
             arn: "???"
           }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-ruby/issues/90

*Description of changes:*
Adding `cloudwatch_logs` to the `aws`  context

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
