### PR TITLE
Update version for 0.15.0 release

### DIFF
--- a/lib/aws-xray-sdk/version.rb
+++ b/lib/aws-xray-sdk/version.rb
@@ -1,3 +1,3 @@
 module XRay
-  VERSION = '0.14.0'
+  VERSION = '0.15.0'
 end


### PR DESCRIPTION
Fast follow up on the 0.15.0 release PR that missed updating the SDK version: https://github.com/aws/aws-xray-sdk-ruby/pull/94


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
