### PR TITLE
Update continuous-build.yml

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
         ruby:
           - 2.4


### PR DESCRIPTION
Fix CI error
```
Error: Error: CRuby < 2.6 does not support macos-arm64.
        Either use a newer Ruby version or use a macOS image running on amd64, e.g., macos-13 or macos-12.
```

the latest macos-14 supports arm only. 
This PR using the previous version of macos image to unblock the release.

*Issue #, if available:*

https://github.com/actions/runner-images/issues/9741

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
