### PR TITLE
fix(daily-scan): suppress multi_json false positive for CVE-2020-10663

### DIFF
--- a/.github/dependency-check-suppressions.xml
+++ b/.github/dependency-check-suppressions.xml
@@ -1,3 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <!--False positive: multi_json gem incorrectly matched to json_project:json CPE (CVE-2020-10663 affects the json gem, not multi_json)-->
+    <suppress>
+        <notes><![CDATA[multi_json is a JSON adapter/wrapper gem, not the json gem affected by CVE-2020-10663. See https://nvd.nist.gov/vuln/detail/CVE-2020-10663]]></notes>
+        <packageUrl regex="true">^pkg:gem/multi_json@.*$</packageUrl>
+        <cpe>cpe:/a:json_project:json</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Problem
DependencyCheck flags `multi_json 1.19.1` for CVE-2020-10663 (HIGH 7.5), but this is a false positive.

CVE-2020-10663 affects the Ruby `json` gem (`json_project:json` CPE) — an unsafe object creation vulnerability in versions ≤ 2.2.0. `multi_json` is a completely different gem; it's a JSON adapter/wrapper that delegates to various backends. DC incorrectly matches it to the `json_project:json` CPE because of the shared word "json".

Evidence from scan log:
```
multi_json-1.19.1.gemspec (cpe:2.3:a:json_project:json:1.19.1): CVE-2020-10663(7.5)
```

## Fix
Add a suppression rule matching `pkg:gem/multi_json@.*` against `cpe:/a:json_project:json`.

## References
- [CVE-2020-10663 on NVD](https://nvd.nist.gov/vuln/detail/CVE-2020-10663)
- [Ruby advisory](https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/)

## Validation
Verified from run [23353740873](https://github.com/aws/aws-xray-sdk-ruby/actions/runs/23353740873).