### PR TITLE
fix(daily-scan): use filePath instead of packageUrl for multi_json suppression

### DIFF
--- a/.github/dependency-check-suppressions.xml
+++ b/.github/dependency-check-suppressions.xml
@@ -3,7 +3,7 @@
     <!--False positive: multi_json gem incorrectly matched to json_project:json CPE (CVE-2020-10663 affects the json gem, not multi_json)-->
     <suppress>
         <notes><![CDATA[multi_json is a JSON adapter/wrapper gem, not the json gem affected by CVE-2020-10663. See https://nvd.nist.gov/vuln/detail/CVE-2020-10663]]></notes>
-        <packageUrl regex="true">^pkg:gem/multi_json@.*$</packageUrl>
+        <filePath regex="true">.*multi_json.*</filePath>
         <cpe>cpe:/a:json_project:json</cpe>
     </suppress>
 </suppressions>


### PR DESCRIPTION
## Problem
The suppression rule from #119 uses `<packageUrl regex="true">^pkg:gem/multi_json@.*$</packageUrl>` but DependencyCheck does not assign a `pkg:gem/` identifier to `.gemspec` files scanned with `--enableExperimental`. The rule had zero matches:

```
[INFO] Suppression Rule had zero matches: SuppressionRule{packageUrl=^pkg:gem/multi_json@.*$, cpe=cpe:/a:json_project:json}
```

CVE-2020-10663 is still being flagged against multi_json despite the suppression.

## Fix
Switch from `<packageUrl>` to `<filePath regex="true">.*multi_json.*</filePath>` which matches the actual file path DC uses internally.

## Validation
Confirmed from run [23355874670](https://github.com/aws/aws-xray-sdk-ruby/actions/runs/23355874670) that the packageUrl approach had zero matches.